### PR TITLE
Add Nix build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import Extension, setup
+from Cython.Build import cythonize
+
+import numpy
+
+sourcefiles = ["cythonizeGraspi/graspi.pyx", "src/graph_constructors.cpp"]
+
+extensions = [
+    Extension(
+        "graspi",
+        sourcefiles,
+        include_dirs=[numpy.get_include(), "src"],
+        extra_compile_args=["-std=c++11"],
+        language="c++",
+    ),
+]
+
+setup(ext_modules=cythonize(extensions, compiler_directives={"language_level": "3"}))

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+{ pkgs ? (import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
+    sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";
+  }) {}) }:
+let
+  pypkgs = pkgs.python3Packages;
+  graspi = pypkgs.buildPythonPackage rec {
+    pname = "graspi";
+    version = "0.1";
+    src = builtins.filterSource (path: type: type != "directory" || baseNameOf path != ".git") ./.;
+    buildInputs = with pypkgs; [
+      cython
+      pkgs.boost
+      numpy
+    ];
+  };
+in
+  pkgs.mkShell rec {
+    pname = "graspi-env";
+    nativeBuildInputs = with pypkgs; [
+      pkgs.boost
+      graspi
+      numpy
+    ];
+  }


### PR DESCRIPTION
Add a [Nix] build for GraSPI.

To test this first install Nix from https://nixos.org/manual/nix/stable/#chap-quick-start and the run `nix-shell` to drop into a shell with a Python environment with required packages.

[Nix]: https://nixos.org/